### PR TITLE
fix: "works at" only for alumni

### DIFF
--- a/src/app/_components/TeamMember/index.tsx
+++ b/src/app/_components/TeamMember/index.tsx
@@ -15,12 +15,13 @@ type TeamMemberProps = {
 const TeamMember = ({ user }: TeamMemberProps) => {
   if (!user) return null;
 
-  // team members use fieldOfStudy and description, alumni use company and position
-  const fieldOfStudy =
+  // team members use fieldOfStudy and description; alumni use company and position
+  const isAlumni = !("fieldOfStudy" in user);
+  const fieldOrCompany =
     "fieldOfStudy" in user ? user.fieldOfStudy : user.company;
   const description = "description" in user ? user.description : user.position;
 
-  const hasOverlay = fieldOfStudy ?? description ?? user.linkedIn ?? false;
+  const hasOverlay = fieldOrCompany ?? description ?? user.linkedIn ?? false;
 
   return (
     <div
@@ -58,8 +59,10 @@ const TeamMember = ({ user }: TeamMemberProps) => {
       {hasOverlay && (
         <div className={styles.hoverOverlay}>
           <div className={styles.overlayContent}>
-            {fieldOfStudy && (
-              <div className={styles.fieldOfStudy}>Works at {fieldOfStudy}</div>
+            {fieldOrCompany && (
+              <div className={styles.fieldOfStudy}>
+                {isAlumni ? `Works at ${fieldOrCompany}` : fieldOrCompany}
+              </div>
             )}
             {description && (
               <div className={styles.description}>{description}</div>


### PR DESCRIPTION
"works at" appears before the major of members of the team, not just alumni rn. 
<img width="376" height="435" alt="Screenshot 2026-03-29 at 7 18 33 PM" src="https://github.com/user-attachments/assets/6651bd03-ebde-4128-91a7-d5125bb1200d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Refined team member card display logic to properly distinguish between alumni and current team members. Alumni now display their company information in hover overlays, while current members show their field of study. This ensures the team members page displays the most relevant professional context for each type of member.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->