### PR TITLE
statically render: /support-us, /, /_not-found, /cars

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,7 +3,6 @@ import { Saira } from "next/font/google";
 
 import "@/styles/globals.scss";
 import { TRPCReactProvider } from "@/trpc/react";
-import { ClerkProvider } from "@clerk/nextjs";
 import { Analytics } from "@vercel/analytics/next";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 
@@ -29,22 +28,12 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <>
-      <ClerkProvider
-        dynamic
-        signInForceRedirectUrl="/portal"
-        signInUrl="/portal/sign-in"
-        signUpForceRedirectUrl="/portal"
-        signUpUrl="/portal/sign-up"
-      >
-        <html className={`${saira.className}`} lang="en">
-          <body>
-            <TRPCReactProvider>{children}</TRPCReactProvider>
-            <Analytics />
-            <SpeedInsights />
-          </body>
-        </html>
-      </ClerkProvider>
-    </>
+    <html className={`${saira.className}`} lang="en">
+      <body>
+        <TRPCReactProvider>{children}</TRPCReactProvider>
+        <Analytics />
+        <SpeedInsights />
+      </body>
+    </html>
   );
 }

--- a/src/app/portal/layout.tsx
+++ b/src/app/portal/layout.tsx
@@ -1,12 +1,23 @@
+import { ClerkProvider } from "@clerk/nextjs";
+
+// export meta
+export const metadata = {
+  title: "Portal - Calgary Solar Car",
+};
 export default function RootLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
   return (
-    <>
-      <title>Calgary Solar Car - Portal</title>
+    <ClerkProvider
+      dynamic
+      signInForceRedirectUrl="/portal"
+      signInUrl="/portal/sign-in"
+      signUpForceRedirectUrl="/portal"
+      signUpUrl="/portal/sign-up"
+    >
       {children}
-    </>
+    </ClerkProvider>
   );
 }


### PR DESCRIPTION
Wrap only the portal in ClerkProvider since we don't need authentication on the public pages.

This pull request refactors how authentication is provided in the app by moving the `ClerkProvider` from the global `RootLayout` to the `/portal` route layout. This ensures that Clerk authentication is only loaded for the portal section, improving performance and separation of concerns. Additionally, metadata for the portal layout is now defined in code.

**Authentication Provider Refactor:**

* Moved the `ClerkProvider` setup from `src/app/layout.tsx` to `src/app/portal/layout.tsx`, so Clerk is only loaded for the `/portal` route instead of the entire app. [[1]](diffhunk://#diff-29d0a55f5ca1a9951042587f8b891bb4cd8b204f5bc855dc2468ed44cde2f5b3L6) [[2]](diffhunk://#diff-29d0a55f5ca1a9951042587f8b891bb4cd8b204f5bc855dc2468ed44cde2f5b3L32-L48) [[3]](diffhunk://#diff-53c07f1e95d3764549c7d6c2c732c937212f9f271ed1110845a018c8b0f5c0c9R1-R21)

**Portal Metadata:**

* Added a `metadata` export to `src/app/portal/layout.tsx` to define the portal page title.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the portal experience to use a dedicated sign-in/sign-up flow with portal-specific redirects.
  * Added a clearer page title for the portal.

* **Bug Fixes**
  * Improved app layout handling so the main site and portal render consistently with the correct structure and authentication behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->