### PR TITLE
statically generate /our-work

### DIFF
--- a/src/app/_components/Footer/index.tsx
+++ b/src/app/_components/Footer/index.tsx
@@ -3,7 +3,6 @@ import { DM_Sans } from "next/font/google";
 import Image from "next/image";
 import Link from "next/link";
 import Logo from "public/assets/logo-nav.png";
-import { memo } from "react";
 
 import styles from "@/app/_components/Footer/index.module.scss";
 
@@ -143,4 +142,4 @@ const Footer = () => {
   );
 };
 
-export default memo(Footer);
+export default Footer;

--- a/src/app/our-work/actions.ts
+++ b/src/app/our-work/actions.ts
@@ -1,0 +1,32 @@
+"use server";
+
+import { db } from "@/server/db";
+
+export async function getOurWork() {
+  const rows = await db.timeline.findMany({
+    orderBy: [{ year: "desc" }, { monthNum: "asc" }],
+    select: {
+      description: true,
+      imageUrl: true,
+      monthName: true,
+      monthNum: true,
+      year: true,
+    },
+  });
+
+  const grouped = rows.reduce<Record<number, typeof rows>>((acc, row) => {
+    (acc[row.year] ??= []).push(row);
+    return acc;
+  }, {});
+
+  return Object.entries(grouped)
+    .sort((a, b) => Number(b[0]) - Number(a[0]))
+    .map(([year, months]) => ({
+      months: months.map((month) => ({
+        description: month.description ?? "",
+        image: month.imageUrl ?? null,
+        month: month.monthName,
+      })),
+      year: String(year),
+    }));
+}

--- a/src/app/our-work/page.tsx
+++ b/src/app/our-work/page.tsx
@@ -1,14 +1,13 @@
-import { memo } from "react";
-
 import Footer from "@/app/_components/Footer";
 import Navbar from "@/app/_components/Navbar";
 import Timeline from "@/app/_components/OurWork/Timeline";
 import Pagebullets from "@/app/_components/Pagebullets";
 import styles from "@/app/our-work/index.module.scss";
-import { trpc } from "@/trpc/server";
+
+import { getOurWork } from "./actions";
 
 const OurWorkTimelinePage = async () => {
-  const timelineData = await trpc.fe.getOurWork();
+  const timelineData = await getOurWork();
 
   return (
     <>
@@ -34,4 +33,4 @@ const OurWorkTimelinePage = async () => {
   );
 };
 
-export default memo(OurWorkTimelinePage);
+export default OurWorkTimelinePage;

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -6,7 +6,6 @@ const isPublicRoute = createRouteMatcher([
   "/api/trpc/fe.getTeamMembers(.*)",
   "/api/trpc/fe.getSponsors(.*)",
   "/api/trpc/fe.getRecruitment(.*)",
-  "/api/trpc/fe.getOurWork(.*)",
   "/",
   "/recruitment",
   "/cars",

--- a/src/server/api/routers/fe.ts
+++ b/src/server/api/routers/fe.ts
@@ -10,7 +10,6 @@ import {
   SponsorshipTeam,
 } from "@/app/_types";
 import { AllTeamRoles, type User } from "@prisma/client";
-import { TRPCError } from "@trpc/server";
 
 import { createTRPCRouter, publicProcedure } from "../trpc";
 
@@ -27,39 +26,6 @@ export const feRouter = createTRPCRouter({
         },
       },
     });
-  }),
-  getOurWork: publicProcedure.query(async ({ ctx }) => {
-    const rows = await ctx.db.timeline.findMany({
-      orderBy: [{ year: "desc" }, { monthNum: "asc" }],
-      select: {
-        description: true,
-        imageUrl: true,
-        monthName: true,
-        monthNum: true,
-        year: true,
-      },
-      where: {
-        deletedAt: null,
-      },
-    });
-
-    const grouped = rows.reduce<Record<number, typeof rows>>((acc, row) => {
-      (acc[row.year] ??= []).push(row);
-      return acc;
-    }, {});
-
-    const timelineData = Object.entries(grouped)
-      .sort((a, b) => Number(b[0]) - Number(a[0]))
-      .map(([year, months]) => ({
-        months: months.map((m) => ({
-          description: m.description ?? "",
-          image: m.imageUrl ?? null,
-          month: m.monthName,
-        })),
-        year: String(year),
-      }));
-
-    return timelineData;
   }),
   getRecruitment: publicProcedure.query(async ({ ctx }) => {
     const forms = await ctx.db.recruitment.findMany({


### PR DESCRIPTION
This pull request refactors how the "Our Work" timeline data is fetched and used in the application. The main change is moving the data fetching logic from the server-side TRPC API to a direct server action, simplifying the data flow and removing unused code. Additionally, some unnecessary imports and memoizations are cleaned up.

**Refactoring data fetching for "Our Work" timeline:**

* Migrated the timeline data fetching logic from the TRPC API (`fe.getOurWork`) to a new server action function `getOurWork` in `src/app/our-work/actions.ts`, which queries the database and groups results by year for use in the UI. [[1]](diffhunk://#diff-d2f7453657e2e42f2bf28e10e48708b580f1da6826495fd5c6b9561612b90a4dR1-R32) [[2]](diffhunk://#diff-8ae8cca49af78633666e0882c6fc754da3ec85cab0164497054a84f4ae2b810cL31-L63)
* Updated the page component in `src/app/our-work/page.tsx` to use the new `getOurWork` server action instead of the TRPC procedure.
* Removed the corresponding public TRPC API endpoint and its route from both the router and the public route matcher. [[1]](diffhunk://#diff-8ae8cca49af78633666e0882c6fc754da3ec85cab0164497054a84f4ae2b810cL31-L63) [[2]](diffhunk://#diff-78bb005ca752086400a648d8aa3e60ce6f666e213da508caabd464d3bfeaf6a2L9)

**Code cleanup:**

* Removed unnecessary imports of `memo` and other unused modules from several files, and stopped memoizing the `Footer` and `OurWorkTimelinePage` components, exporting them directly instead. [[1]](diffhunk://#diff-d7e55d5de54825029a65d38a93bd3d8fb22ab6676ead801922c49168652e0c63L6) [[2]](diffhunk://#diff-d7e55d5de54825029a65d38a93bd3d8fb22ab6676ead801922c49168652e0c63L146-R145) [[3]](diffhunk://#diff-8f7cd6c464d47aa57a9aacd787d3f58b29ab28f9f87591a746a4cba926a1771cL37-R36) [[4]](diffhunk://#diff-8ae8cca49af78633666e0882c6fc754da3ec85cab0164497054a84f4ae2b810cL13)