### PR TITLE
optimize team member photos

### DIFF
--- a/src/app/_components/TeamMember/index.tsx
+++ b/src/app/_components/TeamMember/index.tsx
@@ -42,7 +42,6 @@ const TeamMember = ({ user }: TeamMemberProps) => {
           fill
           loading="eager"
           src={user.profilePictureUrl ?? defaultProfilePicture}
-          unoptimized
         />
       </div>
 


### PR DESCRIPTION
This pull request makes a small change to the `TeamMember` component by removing the `unoptimized` prop from the `Image` element. This will allow Next.js to optimize the user's profile picture by default.